### PR TITLE
Fix #133 - Allow for non-canonical dataframe

### DIFF
--- a/python/nwis_client/src/hydrotools/nwis_client/iv.py
+++ b/python/nwis_client/src/hydrotools/nwis_client/iv.py
@@ -256,7 +256,9 @@ class IVDataService:
         # Empty list. No data was returned in the request
         if not list_of_frames:
             empty_df_warning_helper()
-            return _create_empty_canonical_df()
+            empty_df = _create_empty_canonical_df()
+            empty_df = empty_df.rename(columns={"value_time": self.value_time_label})
+            return empty_df
 
         # Concatenate list in single pd.DataFrame
         dfs = pd.concat(list_of_frames, ignore_index=True)
@@ -264,7 +266,9 @@ class IVDataService:
         # skip data processing steps if no data was retrieved and return empty canonical df
         if dfs.empty:
             empty_df_warning_helper()
-            return _create_empty_canonical_df()
+            empty_df = _create_empty_canonical_df()
+            empty_df = empty_df.rename(columns={"value_time": self.value_time_label})
+            return empty_df
 
         # Convert values to numbers
         dfs.loc[:, "value"] = pd.to_numeric(dfs["value"], downcast="float")

--- a/python/nwis_client/tests/test_nwis.py
+++ b/python/nwis_client/tests/test_nwis.py
@@ -425,14 +425,14 @@ def test_splitting_bbox(test, validation):
     assert v == validation
 
 
-def test_get_returns_empty_canonical_dataframe(setup_iv, monkeypatch):
+def test_get_returns_empty_canonical_dataframe(setup_iv_value_time, monkeypatch):
     """Verify that `get` can returns an empty canonical dataframe."""
 
     def get_raw_mock(*args, **kwargs):
         return [{"values": []}]
 
     monkeypatch.setattr(iv.IVDataService, "get_raw", get_raw_mock)
-    df = setup_iv.get(
+    df = setup_iv_value_time.get(
         sites=["01189000"], startDt="2015-12-01T00:00", endDt="2015-12-31T23:45"
     )
     canonical_df = iv._create_empty_canonical_df()


### PR DESCRIPTION
These minor changes allow for non-canonical dataframes since `nwis_client` is still in transition to adopt the canonical standard per https://github.com/NOAA-OWP/hydrotools/issues/117

